### PR TITLE
Support griffel shorthand spread elements in objects

### DIFF
--- a/src/rules/css-concentric-order/README.md
+++ b/src/rules/css-concentric-order/README.md
@@ -11,6 +11,12 @@ This rule validates JavaScript object based on the following:
 
 See [tests](https://github.com/jchiam/eslint-plugin-css-in-js/tree/master/src/rules/css-concentric-order/index.spec.ts) for examples of valid and invalid object key ordering.
 
+### CSS-in-JS - Griffel
+
+This rule supports Griffel [shorthands](https://github.com/microsoft/griffel/blob/main/packages/core/src/shorthands/index.ts). For shorthands used as spread elements in objects, the shorthand property is treated as CSS property instead.
+
+E.g. `...shorthands.padding` is treated as `padding` during comparisons.
+
 ## Options
 
 This rule takes no options.

--- a/src/rules/css-concentric-order/griffel-shorthands.ts
+++ b/src/rules/css-concentric-order/griffel-shorthands.ts
@@ -1,0 +1,19 @@
+export const griffelShorthandCSSPropertiesSet = new Set([
+  'border',
+  'borderLeft',
+  'borderBottom',
+  'borderRight',
+  'borderTop',
+  'borderColor',
+  'borderStyle',
+  'borderRadius',
+  'borderWidth',
+  'flex',
+  'gap',
+  'gridArea',
+  'margin',
+  'padding',
+  'overflow',
+  'inset',
+  'outline'
+]);

--- a/src/rules/css-concentric-order/index.spec.ts
+++ b/src/rules/css-concentric-order/index.spec.ts
@@ -52,16 +52,16 @@ ruleTester.run('css-concentric-order', rule, {
       };`
     },
     {
-      // TODO: FluentUI shorthands not supported yet
+      // FluentUI, Griffel shorthands follows ordering
       code: `const test = {
         container: {
-          ...shorthands.margin('4px', 0),
           display: 'flex',
           position: 'relative',
           justifyContent: 'center',
+          ...shorthands.margin('4px', 0),
+          ...shorthands.padding('4px', 0),
           lineHeight: 1.6,
-          fontSize: '10px',
-          ...shorthands.padding('4px', 0)
+          fontSize: '10px'
         }
       };`
     },
@@ -125,6 +125,35 @@ ruleTester.run('css-concentric-order', rule, {
           justifyContent: 'center',
 
           position: 'relative',
+          lineHeight: 1.6,
+          fontSize: '10px'
+        }
+      };`,
+      errors: [{ messageId }]
+    },
+    {
+      // FluentUI, Griffel shorthands follows ordering - comparison between shorthand and property
+      code: `const test = {
+        container: {
+          display: 'flex',
+          position: 'relative',
+          justifyContent: 'center',
+          lineHeight: 1.6,
+          fontSize: '10px',
+          ...shorthands.padding('4px', customTokens.contentLeftRightPadding)
+        }
+      };`,
+      errors: [{ messageId }]
+    },
+    {
+      // FluentUI, Griffel shorthands follows ordering - comparison between shorthands
+      code: `const test = {
+        container: {
+          display: 'flex',
+          position: 'relative',
+          justifyContent: 'center',
+          ...shorthands.padding('4px', customTokens.contentLeftRightPadding),
+          ...shorthands.margin('4px', 0),
           lineHeight: 1.6,
           fontSize: '10px'
         }


### PR DESCRIPTION
See [README](https://github.com/jchiam/eslint-plugin-css-in-js/blob/7f417bf11a4d3ccd977676fd5b3cc1a5277cceaf/src/rules/css-concentric-order/README.md).