### PR TITLE
Rename pull_requests.yml to ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Check PR
+wname: Check PR
 
 on:
   push:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-wname: Check PR
+name: Check PR
 
 on:
   push:


### PR DESCRIPTION
## Summary
- Renames `.github/workflows/pull_requests.yml` to `.github/workflows/ci.yml` for a more conventional workflow filename
- Fixes a `wname:` typo (should be `name:`) introduced during the rename that would have broken the workflow

## Test plan
- [x] Confirm the CI workflow runs on the opened PR
- [x] Verify the workflow name displays correctly as "Check PR" in the GitHub Actions tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)