### PR TITLE
1.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jchiam/eslint-plugin-css-in-js",
-  "version": "0.0.3",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jchiam/eslint-plugin-css-in-js",
-      "version": "0.0.3",
+      "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
         "@jchiam/eslint-config": "^5.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jchiam/eslint-plugin-css-in-js",
-  "version": "0.0.3",
+  "version": "1.0.0",
   "description": "A CSS-in-JS plugin for ESLint.",
   "type": "module",
   "main": "lib/index.js",


### PR DESCRIPTION
## Summary
- Bumps the package version to `1.0.0`, marking the first stable major release

## Test plan
- [x] Confirm CI passes on this PR
- [x] Verify `package.json` version is `1.0.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)